### PR TITLE
Add seeding and audit support

### DIFF
--- a/Qurbanet/Controllers/AccountController.cs
+++ b/Qurbanet/Controllers/AccountController.cs
@@ -73,5 +73,12 @@ namespace Qurbanet.Controllers
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
             return RedirectToAction("Index", "Home");
         }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult AccessDenied()
+        {
+            return View();
+        }
     }
 }

--- a/Qurbanet/Controllers/AnimalController.cs
+++ b/Qurbanet/Controllers/AnimalController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Qurbanet.Models.DTOs.Animal;
 using Qurbanet.Services.Interfaces;
+using Qurbanet.Models.Enums;
 
 namespace Qurbanet.Controllers
     [Authorize]
@@ -29,7 +30,7 @@ namespace Qurbanet.Controllers
         }
 
         [HttpGet]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public IActionResult Create(int organizationId)
         {
             ViewBag.OrganizationId = organizationId;
@@ -38,7 +39,7 @@ namespace Qurbanet.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public async Task<IActionResult> Create(CreateAnimalDto dto)
         {
             if (!ModelState.IsValid)

--- a/Qurbanet/Controllers/CustomerController.cs
+++ b/Qurbanet/Controllers/CustomerController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Qurbanet.Models.DTOs.Customer;
 using Qurbanet.Services.Interfaces;
+using Qurbanet.Models.Enums;
 
 namespace Qurbanet.Controllers
 {
@@ -28,7 +29,7 @@ namespace Qurbanet.Controllers
         }
 
         [HttpGet]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public IActionResult Create()
         {
             return View();
@@ -36,7 +37,7 @@ namespace Qurbanet.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public async Task<IActionResult> Create(CreateCustomerDto dto)
         {
             if (!ModelState.IsValid)

--- a/Qurbanet/Controllers/HomeController.cs
+++ b/Qurbanet/Controllers/HomeController.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Qurbanet.Controllers
 {
+    [Authorize]
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
@@ -12,6 +14,12 @@ namespace Qurbanet.Controllers
         }
 
         public IActionResult Index()
+        {
+            return View();
+        }
+
+        [AllowAnonymous]
+        public IActionResult Guide()
         {
             return View();
         }

--- a/Qurbanet/Controllers/OrganizationController.cs
+++ b/Qurbanet/Controllers/OrganizationController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Qurbanet.Models.DTOs.Organization;
 using Qurbanet.Services.Interfaces;
+using Qurbanet.Models.Enums;
 
 namespace Qurbanet.Controllers
 {
@@ -35,7 +36,7 @@ namespace Qurbanet.Controllers
         }
 
         [HttpGet]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public IActionResult Create()
         {
             return View();
@@ -43,7 +44,7 @@ namespace Qurbanet.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public async Task<IActionResult> Create(CreateOrganizationDto dto)
         {
             if (!ModelState.IsValid)

--- a/Qurbanet/Controllers/SaleController.cs
+++ b/Qurbanet/Controllers/SaleController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Qurbanet.Models.DTOs.Sale;
 using Qurbanet.Services.Interfaces;
+using Qurbanet.Models.Enums;
 
 namespace Qurbanet.Controllers
 {
@@ -28,7 +29,7 @@ namespace Qurbanet.Controllers
         }
 
         [HttpGet]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public IActionResult Create()
         {
             return View();
@@ -36,7 +37,7 @@ namespace Qurbanet.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [Authorize(Roles = "Organizer,Admin")]
+        [Authorize(Roles = nameof(UserType.Organizer) + "," + nameof(UserType.Admin))]
         public async Task<IActionResult> Create(CreateSaleDto dto)
         {
             if (!ModelState.IsValid)

--- a/Qurbanet/Controllers/UserController.cs
+++ b/Qurbanet/Controllers/UserController.cs
@@ -3,10 +3,11 @@ using Microsoft.AspNetCore.Mvc;
 using Qurbanet.Helpers;
 using Qurbanet.Models.DTOs.User;
 using Qurbanet.Services.Interfaces;
+using Qurbanet.Models.Enums;
 
 namespace Qurbanet.Controllers
 {
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = nameof(UserType.Admin))]
     public class UserController : Controller
     {
         private readonly IUserService _userService;

--- a/Qurbanet/Database/AppDbContext.cs
+++ b/Qurbanet/Database/AppDbContext.cs
@@ -1,13 +1,18 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Qurbanet.Models.Configurations;
 using Qurbanet.Models.Entities;
+using Qurbanet.Services.Common;
+using System.Threading;
 
 namespace Qurbanet.Database
 {
     public class AppDbContext : DbContext
     {
-        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        private readonly ICurrentUserService _currentUserService;
+
+        public AppDbContext(DbContextOptions<AppDbContext> options, ICurrentUserService currentUserService) : base(options)
         {
+            _currentUserService = currentUserService;
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -38,5 +43,52 @@ namespace Qurbanet.Database
         public DbSet<Payment> Payments { get; set; }
         public DbSet<CuttingEvent> CuttingEvents { get; set; }
         public DbSet<SystemLog> SystemLogs { get; set; }
+
+        private void ApplyAuditInfo()
+        {
+            var entries = ChangeTracker.Entries<BaseModel>();
+            var userId = _currentUserService.UserId ?? 0;
+            var now = DateTime.UtcNow;
+
+            foreach (var entry in entries)
+            {
+                if (entry.State == EntityState.Added)
+                {
+                    entry.Entity.CreateDate = now;
+                    entry.Entity.UpdateDate = now;
+                    entry.Entity.CreateUserId = userId;
+                    entry.Entity.UpdateUserId = userId;
+                    entry.Entity.IsDeleted = false;
+                }
+                else if (entry.State == EntityState.Modified)
+                {
+                    entry.Entity.UpdateDate = now;
+                    entry.Entity.UpdateUserId = userId;
+                    entry.Property(e => e.CreateDate).IsModified = false;
+                    entry.Property(e => e.CreateUserId).IsModified = false;
+                }
+                else if (entry.State == EntityState.Deleted)
+                {
+                    entry.State = EntityState.Modified;
+                    entry.Entity.IsDeleted = true;
+                    entry.Entity.UpdateDate = now;
+                    entry.Entity.UpdateUserId = userId;
+                    entry.Property(e => e.CreateDate).IsModified = false;
+                    entry.Property(e => e.CreateUserId).IsModified = false;
+                }
+            }
+        }
+
+        public override int SaveChanges()
+        {
+            ApplyAuditInfo();
+            return base.SaveChanges();
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            ApplyAuditInfo();
+            return base.SaveChangesAsync(cancellationToken);
+        }
     }
 }

--- a/Qurbanet/Database/DataSeeder.cs
+++ b/Qurbanet/Database/DataSeeder.cs
@@ -1,0 +1,164 @@
+using Microsoft.EntityFrameworkCore;
+using Qurbanet.Models.Entities;
+using Qurbanet.Models.Enums;
+
+namespace Qurbanet.Database
+{
+    public static class DataSeeder
+    {
+        public static async Task SeedAsync(AppDbContext context)
+        {
+            await context.Database.MigrateAsync();
+
+            if (context.Organizations.Any())
+            {
+                return;
+            }
+
+            // create demo users if none exist
+            if (!context.Users.Any())
+            {
+                var demoUser = new User
+                {
+                    Name = "Demo",
+                    Surname = "User",
+                    Username = "demo",
+                    Password = "demo",
+                    Email = "demo@example.com",
+                    Phone = "5550000000",
+                    UserType = UserType.User,
+                    CreateUserId = 0,
+                    UpdateUserId = 0,
+                    CreateDate = DateTime.UtcNow,
+                    UpdateDate = DateTime.UtcNow
+                };
+                var organizer = new User
+                {
+                    Name = "Organizer",
+                    Surname = "User",
+                    Username = "organizer",
+                    Password = "organizer",
+                    Email = "organizer@example.com",
+                    Phone = "5551111111",
+                    UserType = UserType.Organizer,
+                    CreateUserId = 0,
+                    UpdateUserId = 0,
+                    CreateDate = DateTime.UtcNow,
+                    UpdateDate = DateTime.UtcNow
+                };
+                var admin = new User
+                {
+                    Name = "Admin",
+                    Surname = "User",
+                    Username = "admin",
+                    Password = "admin",
+                    Email = "admin@example.com",
+                    Phone = "5552222222",
+                    UserType = UserType.Admin,
+                    CreateUserId = 0,
+                    UpdateUserId = 0,
+                    CreateDate = DateTime.UtcNow,
+                    UpdateDate = DateTime.UtcNow
+                };
+                context.Users.AddRange(demoUser, organizer, admin);
+                await context.SaveChangesAsync();
+            }
+
+            var orgOwner = context.Users.First(u => u.UserType == UserType.Organizer);
+            var organization = new Organization
+            {
+                UserId = orgOwner.Id,
+                Name = "Demo Organizasyon",
+                Year = DateTime.UtcNow.Year,
+                IsPaid = true,
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(1),
+                CreateUserId = orgOwner.Id,
+                UpdateUserId = orgOwner.Id,
+            };
+            context.Organizations.Add(organization);
+            await context.SaveChangesAsync();
+
+            var rnd = new Random();
+            var animals = new List<Animal>();
+            for (int i = 1; i <= 18; i++)
+            {
+                bool sold = rnd.NextDouble() < 0.6;
+                animals.Add(new Animal
+                {
+                    OrganizationId = organization.Id,
+                    NameOrTag = $"A{i:000}",
+                    Species = "Cow",
+                    Breed = "Mixed",
+                    Gender = i % 2 == 0 ? "Male" : "Female",
+                    WeightKg = 250 + rnd.Next(80),
+                    Price = 1000 + rnd.Next(500),
+                    Status = sold ? "Sold" : "Available",
+                    CreateUserId = orgOwner.Id,
+                    UpdateUserId = orgOwner.Id
+                });
+            }
+            context.Animals.AddRange(animals);
+            await context.SaveChangesAsync();
+
+            foreach (var animal in animals.Where(a => a.Status == "Sold"))
+            {
+                var customer = new Customer
+                {
+                    FullName = $"Müşteri {animal.NameOrTag}",
+                    PhoneNumber = "5550000000",
+                    Email = $"customer{animal.NameOrTag}@demo.com",
+                    CreateUserId = orgOwner.Id,
+                    UpdateUserId = orgOwner.Id
+                };
+                context.Customers.Add(customer);
+                await context.SaveChangesAsync();
+
+                decimal paidPortion = (decimal)(0.3 + rnd.NextDouble() * 0.7);
+                var sale = new Sale
+                {
+                    AnimalId = animal.Id,
+                    CustomerId = customer.Id,
+                    SalePrice = animal.Price,
+                    AmountPaid = Math.Round(animal.Price * paidPortion, 2),
+                    SaleDate = DateTime.UtcNow,
+                    CreateUserId = orgOwner.Id,
+                    UpdateUserId = orgOwner.Id
+                };
+                context.Sales.Add(sale);
+                await context.SaveChangesAsync();
+
+                var payment = new Payment
+                {
+                    SaleId = sale.Id,
+                    Amount = sale.AmountPaid,
+                    PaymentDate = DateTime.UtcNow,
+                    CreateUserId = orgOwner.Id,
+                    UpdateUserId = orgOwner.Id
+                };
+                context.Payments.Add(payment);
+                await context.SaveChangesAsync();
+            }
+
+            int order = 1;
+            foreach (var animal in animals)
+            {
+                var stage = (Stage)rnd.Next(1, 5);
+                DateTime start = DateTime.UtcNow.AddHours(-rnd.Next(5));
+                DateTime? end = stage == Stage.Kesim ? null : start.AddHours(1);
+
+                context.CuttingEvents.Add(new CuttingEvent
+                {
+                    AnimalId = animal.Id,
+                    Stage = stage,
+                    StartTime = start,
+                    EndTime = end,
+                    OrderNumber = order++,
+                    CreateUserId = orgOwner.Id,
+                    UpdateUserId = orgOwner.Id
+                });
+            }
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Qurbanet/Database/Repositories/AnimalRepository.cs
+++ b/Qurbanet/Database/Repositories/AnimalRepository.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using Qurbanet.Models.Entities;
+
+namespace Qurbanet.Database.Repositories
+{
+    public class AnimalRepository : BaseRepository<Animal>
+    {
+        public AnimalRepository(AppDbContext context) : base(context)
+        {
+        }
+
+        public async Task<IEnumerable<Animal>> GetByOrganizationAsync(int organizationId)
+        {
+            return await _dbSet.Where(a => a.OrganizationId == organizationId).ToListAsync();
+        }
+    }
+}

--- a/Qurbanet/Extensions/ServiceExtensions.cs
+++ b/Qurbanet/Extensions/ServiceExtensions.cs
@@ -6,6 +6,8 @@ using Qurbanet.Database.Repositories;
 using Qurbanet.Models.Mappers;
 using Qurbanet.Services;
 using Qurbanet.Services.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Qurbanet.Services.Common;
 
 namespace Qurbanet.Extensions
 {
@@ -20,6 +22,9 @@ namespace Qurbanet.Extensions
             // Repository'ler
             services.AddScoped(typeof(BaseRepository<>));
             services.AddScoped<UserRepository>();
+            services.AddScoped<AnimalRepository>();
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddScoped<ICurrentUserService, CurrentUserService>();
 
             // Service'ler
             services.AddScoped<IUserService, UserService>();

--- a/Qurbanet/Helpers/EnumHelper.cs
+++ b/Qurbanet/Helpers/EnumHelper.cs
@@ -22,7 +22,7 @@ namespace Qurbanet.Helpers
                     return (T)Enum.Parse(typeof(T), field.Name);
                 }
             }
-            throw new ArgumentException($"No matching enum value found for description: {description}");
+            throw Constants.CustomExceptions.InvalidFormat;
         }
     }
 }

--- a/Qurbanet/Middlewares/LoggingMiddleware.cs
+++ b/Qurbanet/Middlewares/LoggingMiddleware.cs
@@ -104,7 +104,7 @@ namespace Qurbanet.Middlewares
 
             if (!viewResult.Success)
             {
-                throw new FileNotFoundException($"The view '{viewPath}' was not found.");
+                throw Helpers.Constants.CustomExceptions.NotFound;
             }
 
             var viewContext = new ViewContext(

--- a/Qurbanet/Models/Configurations/CuttingEventConfiguration.cs
+++ b/Qurbanet/Models/Configurations/CuttingEventConfiguration.cs
@@ -13,7 +13,9 @@ namespace Qurbanet.Models.Configurations
 
             builder.ToTable(Constants.Tables.CuttingEvents);
 
-            builder.Property(c => c.Stage).IsRequired();
+            builder.Property(c => c.Stage)
+                .HasConversion<string>()
+                .IsRequired();
             builder.Property(c => c.OrderNumber).IsRequired();
 
             builder.HasOne(c => c.Animal)

--- a/Qurbanet/Models/DTOs/CuttingEvent/CreateCuttingEventDto.cs
+++ b/Qurbanet/Models/DTOs/CuttingEvent/CreateCuttingEventDto.cs
@@ -3,7 +3,7 @@ namespace Qurbanet.Models.DTOs.CuttingEvent
     public class CreateCuttingEventDto
     {
         public int AnimalId { get; set; }
-        public string Stage { get; set; } = null!;
+        public Models.Enums.Stage Stage { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
         public int OrderNumber { get; set; }

--- a/Qurbanet/Models/DTOs/CuttingEvent/CuttingEventDetailsDto.cs
+++ b/Qurbanet/Models/DTOs/CuttingEvent/CuttingEventDetailsDto.cs
@@ -4,7 +4,7 @@ namespace Qurbanet.Models.DTOs.CuttingEvent
     {
         public int Id { get; set; }
         public int AnimalId { get; set; }
-        public string Stage { get; set; } = null!;
+        public Models.Enums.Stage Stage { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
         public int OrderNumber { get; set; }

--- a/Qurbanet/Models/DTOs/CuttingEvent/CuttingEventListDto.cs
+++ b/Qurbanet/Models/DTOs/CuttingEvent/CuttingEventListDto.cs
@@ -4,7 +4,7 @@ namespace Qurbanet.Models.DTOs.CuttingEvent
     {
         public int Id { get; set; }
         public int AnimalId { get; set; }
-        public string Stage { get; set; } = null!;
+        public Models.Enums.Stage Stage { get; set; }
         public int OrderNumber { get; set; }
     }
 }

--- a/Qurbanet/Models/DTOs/CuttingEvent/UpdateCuttingEventDto.cs
+++ b/Qurbanet/Models/DTOs/CuttingEvent/UpdateCuttingEventDto.cs
@@ -4,7 +4,7 @@ namespace Qurbanet.Models.DTOs.CuttingEvent
     {
         public int Id { get; set; }
         public int AnimalId { get; set; }
-        public string Stage { get; set; } = null!;
+        public Models.Enums.Stage Stage { get; set; }
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
         public int OrderNumber { get; set; }

--- a/Qurbanet/Models/Entities/CuttingEvent.cs
+++ b/Qurbanet/Models/Entities/CuttingEvent.cs
@@ -3,7 +3,7 @@ namespace Qurbanet.Models.Entities
     public class CuttingEvent : BaseModel
     {
         public int AnimalId { get; set; }
-        public string Stage { get; set; } = null!; // Kesim, DeriYuzme, Parcalama, Teslim
+        public Models.Enums.Stage Stage { get; set; } // Kesim, DeriYuzme, Parcalama, Teslim
         public DateTime? StartTime { get; set; }
         public DateTime? EndTime { get; set; }
         public int OrderNumber { get; set; }

--- a/Qurbanet/Models/Enums/Stage.cs
+++ b/Qurbanet/Models/Enums/Stage.cs
@@ -1,0 +1,10 @@
+namespace Qurbanet.Models.Enums
+{
+    public enum Stage
+    {
+        Kesim = 1,
+        DeriYuzme = 2,
+        Parcalama = 3,
+        Teslim = 4
+    }
+}

--- a/Qurbanet/Program.cs
+++ b/Qurbanet/Program.cs
@@ -2,11 +2,16 @@ using FluentValidation.AspNetCore;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Qurbanet.Extensions;
 using Qurbanet.Validators.User;
+using Qurbanet.Database;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-    .AddCookie(options => { options.LoginPath = "/Account/Login"; options.LogoutPath = "/Account/Logout"; });
+    .AddCookie(options => {
+        options.LoginPath = "/Account/Login";
+        options.LogoutPath = "/Account/Logout";
+        options.AccessDeniedPath = "/Account/AccessDenied";
+    });
 app.UseAuthentication();
 // Serilog yapýlandýrmasý
 builder.AddSerilogLogging();
@@ -16,6 +21,13 @@ builder.Services.AddControllersWithViews();
 builder.Services.AddApplicationServices(builder.Configuration);
 
 var app = builder.Build();
+
+// Seed demo data
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    await DataSeeder.SeedAsync(db);
+}
 
 // Middlewares
 app.UseCustomMiddlewares();

--- a/Qurbanet/Services/AnimalService.cs
+++ b/Qurbanet/Services/AnimalService.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using Qurbanet.Database;
 using Qurbanet.Models.Entities;
+using Qurbanet.Database.Repositories;
 using Qurbanet.Models.DTOs.Animal;
 using Qurbanet.Services.Interfaces;
 using Qurbanet.Helpers;
@@ -11,19 +12,20 @@ namespace Qurbanet.Services
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly IMapper _mapper;
+        private readonly AnimalRepository _animalRepository;
         private readonly ILogger<AnimalService> _logger;
 
-        public AnimalService(IUnitOfWork unitOfWork, IMapper mapper, ILogger<AnimalService> logger)
+        public AnimalService(IUnitOfWork unitOfWork, IMapper mapper, ILogger<AnimalService> logger, AnimalRepository animalRepository)
         {
             _unitOfWork = unitOfWork;
             _mapper = mapper;
             _logger = logger;
+            _animalRepository = animalRepository;
         }
 
         public async Task<List<AnimalListDto>> GetAllByOrganizationAsync(int organizationId)
         {
-            var repo = _unitOfWork.Repository<Animal>();
-            var list = await repo.FindAsync(a => a.OrganizationId == organizationId);
+            var list = await _animalRepository.GetByOrganizationAsync(organizationId);
             return _mapper.Map<List<AnimalListDto>>(list);
         }
 

--- a/Qurbanet/Services/Common/CurrentUserService.cs
+++ b/Qurbanet/Services/Common/CurrentUserService.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace Qurbanet.Services.Common
+{
+    public class CurrentUserService : ICurrentUserService
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public CurrentUserService(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public int? UserId
+        {
+            get
+            {
+                var user = _httpContextAccessor.HttpContext?.User;
+                if (user?.Identity?.IsAuthenticated ?? false)
+                {
+                    var idString = user.FindFirstValue(ClaimTypes.NameIdentifier);
+                    if (int.TryParse(idString, out var id))
+                    {
+                        return id;
+                    }
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/Qurbanet/Services/Common/ICurrentUserService.cs
+++ b/Qurbanet/Services/Common/ICurrentUserService.cs
@@ -1,0 +1,7 @@
+namespace Qurbanet.Services.Common
+{
+    public interface ICurrentUserService
+    {
+        int? UserId { get; }
+    }
+}

--- a/Qurbanet/Services/OrganizationService.cs
+++ b/Qurbanet/Services/OrganizationService.cs
@@ -73,10 +73,16 @@ namespace Qurbanet.Services
 
             var progress = new OrganizationProgressDto
             {
-                CuttingOrder = events.Where(e => e.Stage == "Kesim" && e.EndTime == null).OrderBy(e => e.OrderNumber).FirstOrDefault()?.OrderNumber,
-                SkinningOrder = events.Where(e => e.Stage == "DeriYüzme" && e.EndTime == null).OrderBy(e => e.OrderNumber).FirstOrDefault()?.OrderNumber,
-                ChoppingOrder = events.Where(e => e.Stage == "Parçalama" && e.EndTime == null).OrderBy(e => e.OrderNumber).FirstOrDefault()?.OrderNumber,
-                DeliveredCount = events.Count(e => e.Stage == "Teslim" && e.EndTime != null)
+                CuttingOrder = events.Where(e => e.Stage == Models.Enums.Stage.Kesim && e.EndTime == null)
+                                      .OrderBy(e => e.OrderNumber)
+                                      .FirstOrDefault()?.OrderNumber,
+                SkinningOrder = events.Where(e => e.Stage == Models.Enums.Stage.DeriYuzme && e.EndTime == null)
+                                       .OrderBy(e => e.OrderNumber)
+                                       .FirstOrDefault()?.OrderNumber,
+                ChoppingOrder = events.Where(e => e.Stage == Models.Enums.Stage.Parcalama && e.EndTime == null)
+                                       .OrderBy(e => e.OrderNumber)
+                                       .FirstOrDefault()?.OrderNumber,
+                DeliveredCount = events.Count(e => e.Stage == Models.Enums.Stage.Teslim && e.EndTime != null)
             };
             return progress;
         }

--- a/Qurbanet/Validators/CuttingEvent/CreateCuttingEventDtoValidator.cs
+++ b/Qurbanet/Validators/CuttingEvent/CreateCuttingEventDtoValidator.cs
@@ -7,7 +7,7 @@ namespace Qurbanet.Validators.CuttingEvent
     {
         public CreateCuttingEventDtoValidator()
         {
-            RuleFor(x => x.Stage).NotEmpty();
+            RuleFor(x => x.Stage).IsInEnum();
             RuleFor(x => x.OrderNumber).GreaterThan(0);
         }
     }

--- a/Qurbanet/Validators/CuttingEvent/UpdateCuttingEventDtoValidator.cs
+++ b/Qurbanet/Validators/CuttingEvent/UpdateCuttingEventDtoValidator.cs
@@ -7,7 +7,7 @@ namespace Qurbanet.Validators.CuttingEvent
     {
         public UpdateCuttingEventDtoValidator()
         {
-            RuleFor(x => x.Stage).NotEmpty();
+            RuleFor(x => x.Stage).IsInEnum();
             RuleFor(x => x.OrderNumber).GreaterThan(0);
         }
     }

--- a/Qurbanet/Views/Account/AccessDenied.cshtml
+++ b/Qurbanet/Views/Account/AccessDenied.cshtml
@@ -1,0 +1,8 @@
+@{
+    ViewData["Title"] = "Access Denied";
+}
+<div class="text-center mt-5">
+    <h1 class="display-4 text-danger">Yetkisiz Erişim</h1>
+    <p class="lead">Bu sayfaya erişim izniniz bulunmamaktadır.</p>
+    <a class="btn btn-primary" asp-controller="Home" asp-action="Index">Ana Sayfaya Dön</a>
+</div>

--- a/Qurbanet/Views/Home/Guide.cshtml
+++ b/Qurbanet/Views/Home/Guide.cshtml
@@ -1,0 +1,14 @@
+@{
+    ViewData["Title"] = "Sistem Rehberi";
+}
+<div class="container mt-5">
+    <h1 class="mb-4">Sistemin Genel Çalışma Mantığı</h1>
+    <ol class="list-group list-group-numbered">
+        <li class="list-group-item">Öncelikle bir organizasyon oluşturun ve başlangıç ile bitiş tarihlerini girin.</li>
+        <li class="list-group-item">Organizasyona ait hayvanları ekleyin. Satılan hayvanlar için satış kayıtları oluşturabilirsiniz.</li>
+        <li class="list-group-item">Satış işlemi sonrası ödemeleri takip edin, tahsilat yapıldıkça ödeme kaydı ekleyin.</li>
+        <li class="list-group-item">Kesim sürecini yönetmek için hayvanlara ait kesim etkinliklerini sırasıyla oluşturun.</li>
+        <li class="list-group-item">Her aşama tamamlandığında etkinliği güncelleyerek süreci ilerletin.</li>
+        <li class="list-group-item">Rapor ve listeler üzerinden organizasyonun genel durumunu izleyebilirsiniz.</li>
+    </ol>
+</div>

--- a/Qurbanet/Views/Shared/_Layout.cshtml
+++ b/Qurbanet/Views/Shared/_Layout.cshtml
@@ -23,6 +23,9 @@
                             <a class="nav-link" asp-controller="Home" asp-action="Index">Ana Sayfa</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" asp-controller="Home" asp-action="Guide">Rehber</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" asp-controller="Organization" asp-action="Index">Organizasyonlar</a>
                         </li>
                         <li class="nav-item">


### PR DESCRIPTION
## Summary
- seed demo organization and animals on startup
- track audit info in `AppDbContext` and soft-delete
- inject current user service for auditing
- create `AnimalRepository` and use it in `AnimalService`
- show a user guide page from layout navigation

## Testing
- `dotnet build Qurbanet.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685087065fe0832cbf8456482a6c4caa